### PR TITLE
Create get API for backend

### DIFF
--- a/apps/elixir_app/lib/modules/api.ex
+++ b/apps/elixir_app/lib/modules/api.ex
@@ -1,0 +1,9 @@
+defmodule Modules.API do
+  alias Modules.Repo
+  alias Modules.Module
+  # import Ecto.Query
+
+  def list_all_modules do
+    Module |> Repo.all
+  end
+end

--- a/apps/elixir_app/lib/modules/modules.ex
+++ b/apps/elixir_app/lib/modules/modules.ex
@@ -1,6 +1,8 @@
 defmodule Modules.Module do
   use Ecto.Schema
 
+  @derive {Poison.Encoder, only: [:module_code, :module_title, :prerequisites]}
+
   schema "modules" do
     field :module_code, :string
     field :module_title, :string

--- a/apps/elixir_app/lib/modules/modules.ex
+++ b/apps/elixir_app/lib/modules/modules.ex
@@ -2,8 +2,15 @@ defmodule Modules.Module do
   use Ecto.Schema
 
   schema "modules" do
-    field(:module_code, :string)
-    field(:module_title, :string)
-    field(:prerequisites, :string)
+    field :module_code, :string
+    field :module_title, :string
+    # Precursors of this module
+    has_many :prerequisites, Modules.Module
+  end
+
+  def changeset(module, params \\ %{}) do
+    module
+    |> Ecto.Changeset.cast(params, [:module_code, :module_title, :prerequisites])
+    |> Ecto.Changeset.validate_required([:module_name, :module_title])
   end
 end

--- a/apps/elixir_app/mix.exs
+++ b/apps/elixir_app/mix.exs
@@ -39,7 +39,8 @@ defmodule ElixirApp.MixProject do
       {:phoenix_pubsub, "~> 2.0"},
       {:ecto_sql, "~> 3.4"},
       {:myxql, ">= 0.0.0"},
-      {:jason, "~> 1.0"}
+      {:jason, "~> 1.0"},
+      {:poison, "~> 3.1"}
     ]
   end
 

--- a/apps/elixir_app/priv/repo/migrations/20210626040341_create_modules.exs
+++ b/apps/elixir_app/priv/repo/migrations/20210626040341_create_modules.exs
@@ -3,9 +3,9 @@ defmodule ElixirApp.Repo.Migrations.CreateModules do
 
   def change do
     create table(:modules) do
-      add(:module_code, :string)
-      add(:module_title, :string)
-      add(:prerequisites, :string)
+      add :module_code, :string
+      add :module_title, :string
+      add :prerequisites, references(:modules)
     end
   end
 end

--- a/apps/elixir_app_web/assets/js/react/App.js
+++ b/apps/elixir_app_web/assets/js/react/App.js
@@ -1,53 +1,22 @@
 import ModuleBubble from "./components/ModuleBubble";
-import React, { useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { Input } from "antd";
 
 import "antd/dist/antd.css"; // or 'antd/dist/antd.less'
 import "./index.css";
 
 function App() {
-  const mods = [
-    {
-      module_code: "CS0101S",
-      module_title: "Programming 0",
-      prerequisites: "None",
-    },
-    {
-      module_code: "CS1101S",
-      module_title: "Programming 1",
-      prerequisites: "None",
-    },
-    {
-      module_code: "CS2101S",
-      module_title: "Programming 2",
-      prerequisites: "None",
-    },
-    {
-      module_code: "CS3101S",
-      module_title: "Programming 3",
-      prerequisites: "None",
-    },
-    {
-      module_code: "CS4101S",
-      module_title: "Programming 4",
-      prerequisites: "None",
-    },
-    {
-      module_code: "CS5101S",
-      module_title: "Programming 5",
-      prerequisites: "None",
-    },
-    {
-      module_code: "CS6101S",
-      module_title: "Programming 6",
-      prerequisites: "None",
-    },
-    {
-      module_code: "CS7101S",
-      module_title: "Programming 7",
-      prerequisites: "None",
-    },
-  ];
+  const [mods, setMods] = useState([])
+
+  useEffect(() => {
+    getMods();
+  }, [])
+
+  const getMods = async () => {
+    const res = await fetch("http://localhost:4000/api/v1/list_all_modules")
+    const data = await res.json();
+    setMods(data);
+  }
 
   return (
     <div>

--- a/apps/elixir_app_web/assets/js/react/App.js
+++ b/apps/elixir_app_web/assets/js/react/App.js
@@ -13,7 +13,7 @@ function App() {
   }, [])
 
   const getMods = async () => {
-    const res = await fetch("http://localhost:4000/api/v1/list_all_modules")
+    const res = await fetch(`http://${window.location.hostname}:${window.location.port}/api/v1/list_all_modules`)
     const data = await res.json();
     setMods(data);
   }

--- a/apps/elixir_app_web/lib/elixir_app_web/controllers/module_controller.ex
+++ b/apps/elixir_app_web/lib/elixir_app_web/controllers/module_controller.ex
@@ -1,0 +1,19 @@
+defmodule ElixirAppWeb.ModuleController do
+  use ElixirAppWeb, :controller
+
+  def decode(item) do
+    {:ok, output} = Poison.encode(item)
+    {:ok, output} = output |> Poison.decode
+    output
+  end
+
+  def index(conn, _params) do
+    modules = Modules.API.list_all_modules()
+    |> Enum.map(&decode/1)
+    render(
+      conn,
+      "index.json",
+      data: modules
+    )
+  end
+end

--- a/apps/elixir_app_web/lib/elixir_app_web/router.ex
+++ b/apps/elixir_app_web/lib/elixir_app_web/router.ex
@@ -37,6 +37,13 @@ defmodule ElixirAppWeb.Router do
     scope "/" do
       pipe_through :browser
       live_dashboard "/dashboard", metrics: ElixirAppWeb.Telemetry
+      scope "/api", ElixirAppWeb do
+        pipe_through :api
+        scope "/v1" do
+          get "/list_all_modules", ModuleController, :index
+        end
+      end
     end
+
   end
 end

--- a/apps/elixir_app_web/lib/elixir_app_web/views/module_view.ex
+++ b/apps/elixir_app_web/lib/elixir_app_web/views/module_view.ex
@@ -1,0 +1,6 @@
+defmodule ElixirAppWeb.ModuleView do
+  use ElixirAppWeb, :view
+  def render("index.json", %{data: modules}) do
+    modules
+  end
+end

--- a/apps/elixir_app_web/mix.exs
+++ b/apps/elixir_app_web/mix.exs
@@ -24,7 +24,7 @@ defmodule ElixirAppWeb.MixProject do
   def application do
     [
       mod: {ElixirAppWeb.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools, :elixir_app]
     ]
   end
 


### PR DESCRIPTION
We now have an API for querying all modules from our database. The endpoint is ```api/v1/list_all_modules```. The front end is using this endpoint to get the data now.
![image](https://user-images.githubusercontent.com/60974969/123513755-69621580-d6c1-11eb-8fc0-e4d7f6bf208e.png)
